### PR TITLE
Update New-WinSCPSession.ps1

### DIFF
--- a/Functions/New-WinSCPSession.ps1
+++ b/Functions/New-WinSCPSession.ps1
@@ -85,7 +85,11 @@ Function New-WinSCPSession
     (
         [Parameter(ValueFromPipeline = $true)]
         [PSCredential]
-        $Credential = (Get-Credential),
+        $Credential = $null,
+
+        [Parameter(ValueFromPipeline = $true)]
+        [String]
+        $UserName = $null,
 
         [Parameter()]
         [WinSCP.FtpMode]
@@ -197,8 +201,15 @@ Function New-WinSCPSession
     $sessionOptions = New-Object -TypeName WinSCP.SessionOptions
     $session = New-Object -TypeName WinSCP.Session
 
-    # Convert PSCredential Object to match names of the WinSCP.SessionOptions Object.
-    $PSBoundParameters.Add('UserName', $Credential.UserName)
+    if (-not($UserName) -and -not($Credential))
+	{
+		$Credential = Get-Credential
+	}
+
+	if (-not($UserName) )
+	{
+		$PSBoundParameters.Add('UserName', $Credential.UserName)
+	}
     $PSBoundParameters.Add('SecurePassword', $Credential.Password)
 
     # Convert SshPrivateKeySecurePasspahrase to plain text and set it to the corresponding SessionOptions property.


### PR DESCRIPTION
There are some scenarios where the password is not required but just the UserName. A typical scenario regards the use of the privatekey. The Credential object is not easy to use because it cannot be created with a null or blank password.
You have to specify a dummy password using the following code:
$dummypassword = ConvertTo-SecureString "dummypwds"  -asplaintext -force
$credential = new-object -typename System.Management.Automation.PSCredential -argumentlist $user, $dummypassword
It is not user friendly, just to enter a username!
I propose to create a new parameter, UserName, to manage those scenarios instead of the Credential object.
Kind Regards